### PR TITLE
Trying out GraphQL.Content as a sum type to see if this is compatible with the API

### DIFF
--- a/Sources/Buildkite/Networking/StatusCode.swift
+++ b/Sources/Buildkite/Networking/StatusCode.swift
@@ -21,7 +21,7 @@ public enum StatusCode: Int, Error, Codable {
 
     /// The request has been accepted, but not yet processed.
     case accepted = 202
-    
+
     /// The request has been successfully processed, and is not returning any content
     case noContent = 204
 
@@ -48,7 +48,7 @@ public enum StatusCode: Int, Error, Codable {
 
     /// An internal error occurred in Buildkite.
     case internalServerError = 500
-    
+
     /// The server was acting as a gateway or proxy and received an invalid response from the upstream server.
     case badGateway = 502
 

--- a/Sources/Buildkite/Resources/GraphQL.swift
+++ b/Sources/Buildkite/Resources/GraphQL.swift
@@ -20,21 +20,41 @@ public struct GraphQL<T: Decodable>: Resource, HasResponseBody, HasRequestBody {
         public var variables: JSONValue
     }
 
-    public struct Content: Decodable {
-        public var data: T?
-        public var type: String?
-        public var errors: [Error]?
+    // Making a design decision here to forbid supplying data and errors
+    // simultaneously. The GraphQL spec permits it but multiple implementations,
+    // seemingly including Buildkite's, choose not to.
+    public enum Content: Error, Decodable {
+        case data(T)
+        case errors([Error], type: String?)
 
-        public struct Error: Swift.Error, Decodable {
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let errors = try container.decodeIfPresent([Error].self, forKey: .errors) {
+                let type = try container.decodeIfPresent(String.self, forKey: .type)
+                self = .errors(errors, type: type)
+            } else if let data = try container.decodeIfPresent(T.self, forKey: .data) {
+                self = .data(data)
+            } else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "The GraphQL response does not contain either errors or data. One is required. If errors are present, they will be considered instead of any data that may have also been sent."))
+            }
+        }
+
+        public struct Error: Swift.Error, Equatable, Hashable, Decodable {
             public var message: String
             public var locations: [Location]?
             public var path: [String]?
             public var extensions: JSONValue?
 
-            public struct Location: Decodable {
+            public struct Location: Equatable, Hashable, Decodable {
                 public var line: Int
                 public var column: Int
             }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case data
+            case type
+            case errors
         }
     }
 
@@ -54,3 +74,6 @@ public struct GraphQL<T: Decodable>: Resource, HasResponseBody, HasRequestBody {
         request.httpMethod = "POST"
     }
 }
+
+extension GraphQL.Content: Equatable where T: Equatable {}
+extension GraphQL.Content: Hashable where T: Hashable {}

--- a/Tests/BuildkiteTests/Networking/JSONValueTests.swift
+++ b/Tests/BuildkiteTests/Networking/JSONValueTests.swift
@@ -113,4 +113,29 @@ final class JSONValueTests: XCTestCase {
         let actual = try JSONDecoder().decode(JSONValue.self, from: JSONEncoder().encode(expected))
         XCTAssertEqual(expected, actual)
     }
+
+    func testSubscripts() throws {
+        let abcs: JSONValue = ["a", "b", "c"]
+        let oneTwoThrees: JSONValue = ["1": 1, "2": 2, "3": 3]
+        let expected: JSONValue = ["foo": ["bar": false, "baz": abcs, "qux": oneTwoThrees]]
+
+        XCTAssertNil(expected[expected])
+        XCTAssertNil(expected[abcs])
+        XCTAssertNil(expected[false])
+        XCTAssertNil(expected[1])
+
+        XCTAssertNil(abcs["0"])
+        XCTAssertNotNil(abcs[0])
+        XCTAssertEqual(abcs[1], abcs[.number(1)])
+
+        XCTAssertNil(oneTwoThrees[1])
+        XCTAssertNotNil(oneTwoThrees["1"])
+        XCTAssertEqual(oneTwoThrees["1"], oneTwoThrees[.string("1")])
+
+        XCTAssertEqual(expected.foo, expected["foo"])
+        XCTAssertEqual(expected.foo?.bar, false)
+        XCTAssertEqual(expected.foo?.baz, abcs)
+        XCTAssertEqual(expected.foo?.qux, oneTwoThrees)
+
+    }
 }

--- a/Tests/BuildkiteTests/Resources/GraphQLTests.swift
+++ b/Tests/BuildkiteTests/Resources/GraphQLTests.swift
@@ -15,7 +15,7 @@ import FoundationNetworking
 #endif
 
 class GraphQLTests: XCTestCase {
-    func testGraphQL() throws {
+    func testGraphQLSuccess() throws {
         let expected: JSONValue = ["jeff": [1, 2, 3], "horses": false]
         let content: JSONValue = ["data": expected]
         let context = try MockContext(content: content)
@@ -25,10 +25,76 @@ class GraphQLTests: XCTestCase {
         context.client.send(GraphQL<JSONValue>(rawQuery: "query MyQuery{jeff,horses}", variables: [:])) { result in
             do {
                 let response = try result.get()
-                XCTAssertEqual(expected, response.content.data)
+                XCTAssertEqual(GraphQL.Content.data(expected), response.content)
             } catch {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testGraphQLErrors() throws {
+        let expectedErrors: [GraphQL<JSONValue>.Content.Error] = [
+            .init(message: "Field 'id' doesn't exist on type 'Query'",
+                  locations: [.init(line: 2, column: 3)],
+                  path: ["query SimpleQuery", "id"],
+                  extensions: [
+                    "code": "undefinedField",
+                    "typeName": "Query",
+                    "fieldName": "id"
+            ])
+        ]
+        let expected: GraphQL<JSONValue>.Content = .errors(expectedErrors, type: nil)
+        let content: JSONValue = [
+            "errors": .array(expectedErrors.map { error in
+                let messageJSON: JSONValue = .string(error.message)
+                let locationsJSON: JSONValue
+                if let locations = error.locations {
+                    locationsJSON = .array(locations.map { .object(["line": .number(Double($0.line)), "column": .number(Double($0.column))]) })
+                } else {
+                    locationsJSON = .null
+                }
+                let pathJSON: JSONValue
+                if let path = error.path {
+                    pathJSON = .array(path.map { .string($0) })
+                } else {
+                    pathJSON = .null
+                }
+                let extensionsJSON = error.extensions ?? .null
+
+                return [
+                    "message": messageJSON,
+                    "locations": locationsJSON,
+                    "path": pathJSON,
+                    "extensions": extensionsJSON
+                ]
+            })
+        ]
+        let context = try MockContext(content: content)
+
+        let expectation = XCTestExpectation()
+
+        context.client.send(GraphQL<JSONValue>(rawQuery: "query MyQuery{jeff,horses}", variables: [:])) { result in
+            do {
+                let response = try result.get()
+                XCTAssertEqual(expected, response.content)
+            } catch {
+                XCTFail(error.localizedDescription)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+    }
+
+    func testGraphQLIncompatibleResponse() throws {
+        let content: JSONValue = [:]
+        let context = try MockContext(content: content)
+
+        let expectation = XCTestExpectation()
+
+        context.client.send(GraphQL<JSONValue>(rawQuery: "", variables: [:])) {
+            try? XCTAssertThrowsError($0.get(), "Expected to have failed with an error, but closure fulfilled normally")
             expectation.fulfill()
         }
         wait(for: [expectation])


### PR DESCRIPTION
- [x] confirmed with Buildkite team that their GraphQL stack can't send errors and data simultaneously

Fixes #1 