### PR TITLE
Support tokens as a dynamic, generic construct

### DIFF
--- a/Examples/graphql/GraphQLExample.swift
+++ b/Examples/graphql/GraphQLExample.swift
@@ -31,8 +31,7 @@ struct MyPipeline: Codable {
 
 @main struct GraphQLExample {
     static func main() async {
-        let client = BuildkiteClient()
-        client.token = "..."
+        let client = BuildkiteClient(token: "...")
 
         let query = """
         query MyPipelines($first: Int!) {

--- a/Sources/Buildkite/Buildkite.docc/Articles/Authorization.md
+++ b/Sources/Buildkite/Buildkite.docc/Articles/Authorization.md
@@ -1,0 +1,33 @@
+# Authorization
+
+Buildkite supports resources across several different APIs with a variety of versions and authorization interfaces. ``BuildkiteClient`` has built-in support to interoperate between the different APIs from a single client. 
+
+## Overview
+
+The most basic means of authorizing with a single service in Buildkite is by the declaration of a fixed token string. The client instance will store a copy of this string in memory and use it with all subsequent requests.
+
+```swift
+let client = BuildkiteClient(token: "...")
+```
+
+Sometimes you may want to keep control of the token, either to customize how it's loaded from a credential store, or more commonly, to provide a different token based on the Buildkite API you are targeting. To opt-in to this behavior, implement your own ``TokenProvider`` type to manage your token and provide that to the ``BuildkiteClient`` when it's created.  
+
+```swift
+struct MyTokenProvider: TokenProvider {
+    let myGraphQLToken: String = "..."
+    let myRESTToken: String = "..."
+
+    func token(for version: APIVersion) -> String? {
+        switch version {
+        case .GraphQL.v1:
+            return myGraphQLToken
+        case .REST.v2:
+            return myRESTToken
+        default:
+            return nil
+        }
+    }
+}
+
+let client = BuildkiteClient(tokens: MyTokenProvider())
+```

--- a/Sources/Buildkite/Buildkite.docc/Articles/GettingStarted.md
+++ b/Sources/Buildkite/Buildkite.docc/Articles/GettingStarted.md
@@ -12,12 +12,13 @@ In order to access the Buildkite API you must first create an API access token. 
 
 ### Create a Buildkite Client
 
-Creating a client object is as simple as calling the default initializer, and then assigning your token. 
+Creating a client object is as simple as calling the default initializer with an authorization token. 
 
 ```swift
-let client = BuildkiteClient()
-client.token = "..." // Your scoped Buildkite API access token
+let client = BuildkiteClient(token: "...") // Using your scoped Buildkite API access token
 ```
+
+For more advanced authorization features, see <doc:Authorization>.
 
 ### Send a Resource
 
@@ -53,8 +54,3 @@ client.sendPublisher(.pipelines(in: "buildkite"))
         print(pipelines)
     }.store(in: &cancellables)
 ```
-
-## Topics
-
-- ``BuildkiteClient``
-- ``Pipeline/Resources/List``

--- a/Sources/Buildkite/Buildkite.docc/Articles/UsingGraphQL.md
+++ b/Sources/Buildkite/Buildkite.docc/Articles/UsingGraphQL.md
@@ -29,7 +29,3 @@ let pipeline: Pipelines = try await client.sendQuery(resource)
 ```
 
 The helper method `sendQuery` can be used to automatically extract the data from a GraphQL response, without having to juggle HTTP, decoding and schema errors in separate calls. You can still use any of the `send` or `sendPublisher` methods to process a GraphQL query, if you require the response data as well. 
-
-## Topics
-
-- ``GraphQL``

--- a/Sources/Buildkite/Buildkite.docc/Buildkite.md
+++ b/Sources/Buildkite/Buildkite.docc/Buildkite.md
@@ -59,9 +59,11 @@ The entire publicly documented REST API surface is supported by this package.
 
 ### Advanced
 
+- <doc:Authorization>
 - ``Configuration``
 - ``APIVersion``
 - ``Transport``
+- ``TokenProvider``
 - ``Response``
 - ``StatusCode``
 - ``BuildkiteError``

--- a/Sources/Buildkite/Buildkite.docc/Extensions/BuildkiteClient.md
+++ b/Sources/Buildkite/Buildkite.docc/Extensions/BuildkiteClient.md
@@ -4,8 +4,8 @@
 
 ### Creating a Client
 
-- ``init(configuration:transport:)``
-- ``token``
+- ``init(configuration:transport:tokens:)``
+- ``init(configuration:transport:token:)``
 
 ### Sending Resources
 

--- a/Sources/Buildkite/BuildkiteClient.swift
+++ b/Sources/Buildkite/BuildkiteClient.swift
@@ -31,17 +31,10 @@ public final class BuildkiteClient {
     var configuration: Configuration
 
     /// The network (or whatever) transport layer. Implemented by URLSession by default.
-    private var transport: Transport
+    var transport: Transport
 
     /// Convenience property for setting the access token used by the client.
-    public var token: String? {
-        get {
-            configuration.token
-        }
-        set {
-            configuration.token = newValue
-        }
-    }
+    var tokens: TokenProvider?
 
     /// Creates a session with the specified configuration and transport layer.
     /// - Parameters:
@@ -49,10 +42,12 @@ public final class BuildkiteClient {
     ///   - transport: Transport layer used for API communication. Uses the shared URLSession by default.
     public init(
         configuration: Configuration = .default,
-        transport: Transport = URLSession.shared
+        transport: Transport = URLSession.shared,
+        tokens: TokenProvider? = nil
     ) {
         self.configuration = configuration
         self.transport = transport
+        self.tokens = tokens
     }
 
     private func handleContentfulResponse<Content: Decodable>(
@@ -123,7 +118,7 @@ extension BuildkiteClient {
     public func send<R>(_ resource: R, completion: @escaping (Result<Response<R.Content>, Error>) -> Void)
     where R: Resource, R.Content: Decodable {
         do {
-            let request = try URLRequest(resource, configuration: configuration)
+            let request = try URLRequest(resource, configuration: configuration, tokens: tokens)
             transport.send(request: request, completion: handleContentfulResponse(completion: completion))
         } catch {
             completion(.failure(error))
@@ -141,7 +136,12 @@ extension BuildkiteClient {
         completion: @escaping (Result<Response<R.Content>, Error>) -> Void
     ) where R: PaginatedResource {
         do {
-            let request = try URLRequest(resource, configuration: configuration, pageOptions: pageOptions)
+            let request = try URLRequest(
+                resource,
+                configuration: configuration,
+                tokens: tokens,
+                pageOptions: pageOptions
+            )
             transport.send(request: request, completion: handleContentfulResponse(completion: completion))
         } catch {
             completion(.failure(error))
@@ -155,7 +155,7 @@ extension BuildkiteClient {
     public func send<R>(_ resource: R, completion: @escaping (Result<Response<R.Content>, Error>) -> Void)
     where R: Resource, R.Body: Encodable, R.Content: Decodable {
         do {
-            let request = try URLRequest(resource, configuration: configuration, encoder: encoder)
+            let request = try URLRequest(resource, configuration: configuration, tokens: tokens, encoder: encoder)
             transport.send(request: request, completion: handleContentfulResponse(completion: completion))
         } catch {
             completion(.failure(error))
@@ -176,6 +176,7 @@ extension BuildkiteClient {
             let request = try URLRequest(
                 resource,
                 configuration: configuration,
+                tokens: tokens,
                 encoder: encoder,
                 pageOptions: pageOptions
             )
@@ -192,7 +193,7 @@ extension BuildkiteClient {
     public func send<R>(_ resource: R, completion: @escaping (Result<Response<R.Content>, Error>) -> Void)
     where R: Resource, R.Content == Void {
         do {
-            let request = try URLRequest(resource, configuration: configuration)
+            let request = try URLRequest(resource, configuration: configuration, tokens: tokens)
             transport.send(request: request, completion: handleEmptyResponse(completion: completion))
         } catch {
             completion(.failure(error))
@@ -206,7 +207,7 @@ extension BuildkiteClient {
     public func send<R>(_ resource: R, completion: @escaping (Result<Response<R.Content>, Error>) -> Void)
     where R: Resource, R.Body: Encodable, R.Content == Void {
         do {
-            let request = try URLRequest(resource, configuration: configuration, encoder: encoder)
+            let request = try URLRequest(resource, configuration: configuration, tokens: tokens, encoder: encoder)
             transport.send(request: request, completion: handleEmptyResponse(completion: completion))
         } catch {
             completion(.failure(error))
@@ -244,7 +245,7 @@ extension BuildkiteClient {
     /// - Returns: The publisher publishes the response when the operation completes, or terminates if the operation fails with an error.
     public func sendPublisher<R>(_ resource: R) -> AnyPublisher<Response<R.Content>, Error>
     where R: Resource, R.Content: Decodable {
-        Result { try URLRequest(resource, configuration: configuration) }
+        Result { try URLRequest(resource, configuration: configuration, tokens: tokens) }
             .publisher
             .flatMap(transport.sendPublisher)
             .tryMap {
@@ -264,7 +265,7 @@ extension BuildkiteClient {
         _ resource: R,
         pageOptions: PageOptions? = nil
     ) -> AnyPublisher<Response<R.Content>, Error> where R: PaginatedResource {
-        Result { try URLRequest(resource, configuration: configuration, pageOptions: pageOptions) }
+        Result { try URLRequest(resource, configuration: configuration, tokens: tokens, pageOptions: pageOptions) }
             .publisher
             .flatMap(transport.sendPublisher)
             .tryMap {
@@ -280,7 +281,7 @@ extension BuildkiteClient {
     /// - Returns: The publisher publishes the response when the operation completes, or terminates if the operation fails with an error.
     public func sendPublisher<R>(_ resource: R) -> AnyPublisher<Response<R.Content>, Error>
     where R: Resource, R.Body: Encodable, R.Content: Decodable {
-        Result { try URLRequest(resource, configuration: configuration, encoder: encoder) }
+        Result { try URLRequest(resource, configuration: configuration, tokens: tokens, encoder: encoder) }
             .publisher
             .flatMap(transport.sendPublisher)
             .tryMap {
@@ -300,15 +301,23 @@ extension BuildkiteClient {
         _ resource: R,
         pageOptions: PageOptions? = nil
     ) -> AnyPublisher<Response<R.Content>, Error> where R: PaginatedResource, R.Body: Encodable {
-        Result { try URLRequest(resource, configuration: configuration, encoder: encoder, pageOptions: pageOptions) }
-            .publisher
-            .flatMap(transport.sendPublisher)
-            .tryMap {
-                try self.checkResponseForIssues($0.response, data: $0.data)
-                let content = try self.decoder.decode(R.Content.self, from: $0.data)
-                return Response(content: content, response: $0.response)
-            }
-            .eraseToAnyPublisher()
+        Result {
+            try URLRequest(
+                resource,
+                configuration: configuration,
+                tokens: tokens,
+                encoder: encoder,
+                pageOptions: pageOptions
+            )
+        }
+        .publisher
+        .flatMap(transport.sendPublisher)
+        .tryMap {
+            try self.checkResponseForIssues($0.response, data: $0.data)
+            let content = try self.decoder.decode(R.Content.self, from: $0.data)
+            return Response(content: content, response: $0.response)
+        }
+        .eraseToAnyPublisher()
     }
 
     /// Performs the given resource and publishes the response asynchronously.
@@ -316,7 +325,7 @@ extension BuildkiteClient {
     /// - Returns: The publisher publishes the response when the operation completes, or terminates if the operation fails with an error.
     public func sendPublisher<R>(_ resource: R) -> AnyPublisher<Response<R.Content>, Error>
     where R: Resource, R.Content == Void {
-        Result { try URLRequest(resource, configuration: configuration) }
+        Result { try URLRequest(resource, configuration: configuration, tokens: tokens) }
             .publisher
             .flatMap(transport.sendPublisher)
             .tryMap {
@@ -331,7 +340,7 @@ extension BuildkiteClient {
     /// - Returns: The publisher publishes the response when the operation completes, or terminates if the operation fails with an error.
     public func sendPublisher<R>(_ resource: R) -> AnyPublisher<Response<R.Content>, Error>
     where R: Resource, R.Body: Encodable, R.Content == Void {
-        Result { try URLRequest(resource, configuration: configuration, encoder: encoder) }
+        Result { try URLRequest(resource, configuration: configuration, tokens: tokens, encoder: encoder) }
             .publisher
             .flatMap(transport.sendPublisher)
             .tryMap {
@@ -360,7 +369,7 @@ extension BuildkiteClient {
     /// - Parameter resource: A resource.
     /// - Returns: A response containing the content of the response body, as well as other information about the HTTP operation.
     public func send<R>(_ resource: R) async throws -> Response<R.Content> where R: Resource, R.Content: Decodable {
-        let request = try URLRequest(resource, configuration: configuration)
+        let request = try URLRequest(resource, configuration: configuration, tokens: tokens)
         let (data, response) = try await transport.send(request: request)
         try checkResponseForIssues(response, data: data)
         let content = try self.decoder.decode(R.Content.self, from: data)
@@ -374,7 +383,7 @@ extension BuildkiteClient {
     /// - Returns: A response containing the content of the response body, as well as other information about the HTTP operation.
     public func send<R>(_ resource: R, pageOptions: PageOptions? = nil) async throws -> Response<R.Content>
     where R: PaginatedResource {
-        let request = try URLRequest(resource, configuration: configuration, pageOptions: pageOptions)
+        let request = try URLRequest(resource, configuration: configuration, tokens: tokens, pageOptions: pageOptions)
         let (data, response) = try await transport.send(request: request)
         try checkResponseForIssues(response, data: data)
         let content = try self.decoder.decode(R.Content.self, from: data)
@@ -386,7 +395,7 @@ extension BuildkiteClient {
     /// - Returns: A response containing the content of the response body, as well as other information about the HTTP operation.
     public func send<R>(_ resource: R) async throws -> Response<R.Content>
     where R: Resource, R.Body: Encodable, R.Content: Decodable {
-        let request = try URLRequest(resource, configuration: configuration, encoder: encoder)
+        let request = try URLRequest(resource, configuration: configuration, tokens: tokens, encoder: encoder)
         let (data, response) = try await transport.send(request: request)
         try checkResponseForIssues(response, data: data)
         let content = try self.decoder.decode(R.Content.self, from: data)
@@ -400,7 +409,13 @@ extension BuildkiteClient {
     /// - Returns: A response containing the content of the response body, as well as other information about the HTTP operation.
     public func send<R>(_ resource: R, pageOptions: PageOptions? = nil) async throws -> Response<R.Content>
     where R: PaginatedResource, R.Body: Encodable {
-        let request = try URLRequest(resource, configuration: configuration, encoder: encoder, pageOptions: pageOptions)
+        let request = try URLRequest(
+            resource,
+            configuration: configuration,
+            tokens: tokens,
+            encoder: encoder,
+            pageOptions: pageOptions
+        )
 
         let (data, response) = try await transport.send(request: request)
         try checkResponseForIssues(response, data: data)
@@ -412,7 +427,7 @@ extension BuildkiteClient {
     /// - Parameter resource: A resource.
     /// - Returns: A response containing the content of the response body, as well as other information about the HTTP operation.
     public func send<R>(_ resource: R) async throws -> Response<R.Content> where R: Resource, R.Content == Void {
-        let request = try URLRequest(resource, configuration: configuration)
+        let request = try URLRequest(resource, configuration: configuration, tokens: tokens)
         let (data, response) = try await transport.send(request: request)
         try checkResponseForIssues(response, data: data)
         return Response(content: (), response: response)
@@ -423,7 +438,7 @@ extension BuildkiteClient {
     /// - Returns: A response containing information about the HTTP operation, and no content.
     public func send<R>(_ resource: R) async throws -> Response<R.Content>
     where R: Resource, R.Body: Encodable, R.Content == Void {
-        let request = try URLRequest(resource, configuration: configuration, encoder: encoder)
+        let request = try URLRequest(resource, configuration: configuration, tokens: tokens, encoder: encoder)
         let (data, response) = try await transport.send(request: request)
         try checkResponseForIssues(response, data: data)
         return Response(content: (), response: response)

--- a/Sources/Buildkite/BuildkiteClient.swift
+++ b/Sources/Buildkite/BuildkiteClient.swift
@@ -36,10 +36,11 @@ public final class BuildkiteClient {
     /// Convenience property for setting the access token used by the client.
     var tokens: TokenProvider?
 
-    /// Creates a session with the specified configuration and transport layer.
+    /// Creates a session with the specified configuration, transport layer, and token provider.
     /// - Parameters:
-    ///   - configuration: Configures supported API versions and the access token. Uses the latest supported API versions by default. See ``token`` for setting the client access token if using the default configuration.
+    ///   - configuration: Configures supported API versions and the access token. Uses the latest supported API versions by default.
     ///   - transport: Transport layer used for API communication. Uses the shared URLSession by default.
+    ///   - tokens: Token provider used for authorization. Unauthenticated by default.
     public init(
         configuration: Configuration = .default,
         transport: Transport = URLSession.shared,
@@ -48,6 +49,19 @@ public final class BuildkiteClient {
         self.configuration = configuration
         self.transport = transport
         self.tokens = tokens
+    }
+
+    /// Creates a session with the specified configuration, transport layer, and fixed token string.
+    /// - Parameters:
+    ///   - configuration: Configures supported API versions and the access token. Uses the latest supported API versions by default.
+    ///   - transport: Transport layer used for API communication. Uses the shared URLSession by default.
+    ///   - token: Raw token used for authorization.
+    public convenience init(
+        configuration: Configuration = .default,
+        transport: Transport = URLSession.shared,
+        token: String
+    ) {
+        self.init(configuration: configuration, transport: transport, tokens: RawTokenProvider(rawValue: token))
     }
 
     private func handleContentfulResponse<Content: Decodable>(

--- a/Sources/Buildkite/Networking/Configuration.swift
+++ b/Sources/Buildkite/Networking/Configuration.swift
@@ -32,12 +32,14 @@ public struct Configuration {
         self.graphQLVersion = graphQLVersion
     }
 
-    var token: String?
-
-    func transformRequest(_ request: inout URLRequest) {
+    func transformRequest(
+        _ request: inout URLRequest,
+        tokens: TokenProvider?,
+        version: APIVersion
+    ) {
         request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
-        if let token = token {
-            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let header = tokens?.authorizationHeader(for: version) {
+            request.addValue(header, forHTTPHeaderField: "Authorization")
         }
     }
 

--- a/Sources/Buildkite/Networking/Resource.swift
+++ b/Sources/Buildkite/Networking/Resource.swift
@@ -45,7 +45,8 @@ public protocol PaginatedResource: Resource where Content: Decodable {}
 extension URLRequest {
     init<R: Resource>(
         _ resource: R,
-        configuration: Configuration
+        configuration: Configuration,
+        tokens: TokenProvider?
     ) throws {
         let version = resource.version
         guard
@@ -57,7 +58,7 @@ extension URLRequest {
 
         let url = version.url(for: resource.path)
         var request = URLRequest(url: url)
-        configuration.transformRequest(&request)
+        configuration.transformRequest(&request, tokens: tokens, version: version)
         resource.transformRequest(&request)
 
         self = request
@@ -66,18 +67,20 @@ extension URLRequest {
     init<R: Resource>(
         _ resource: R,
         configuration: Configuration,
+        tokens: TokenProvider?,
         encoder: JSONEncoder
     ) throws where R.Body: Encodable {
-        try self.init(resource, configuration: configuration)
+        try self.init(resource, configuration: configuration, tokens: tokens)
         httpBody = try encoder.encode(resource.body)
     }
 
     init<R: Resource & PaginatedResource>(
         _ resource: R,
         configuration: Configuration,
+        tokens: TokenProvider?,
         pageOptions: PageOptions? = nil
     ) throws {
-        try self.init(resource, configuration: configuration)
+        try self.init(resource, configuration: configuration, tokens: tokens)
         if let options = pageOptions {
             appendPageOptions(options)
         }
@@ -86,10 +89,11 @@ extension URLRequest {
     init<R: Resource & PaginatedResource>(
         _ resource: R,
         configuration: Configuration,
+        tokens: TokenProvider?,
         encoder: JSONEncoder,
         pageOptions: PageOptions? = nil
     ) throws where R.Body: Encodable {
-        try self.init(resource, configuration: configuration, encoder: encoder)
+        try self.init(resource, configuration: configuration, tokens: tokens, encoder: encoder)
         if let options = pageOptions {
             appendPageOptions(options)
         }

--- a/Sources/Buildkite/Networking/TokenProvider.swift
+++ b/Sources/Buildkite/Networking/TokenProvider.swift
@@ -1,0 +1,36 @@
+//
+//  TokenProvider.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/5/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol TokenProvider {
+    func token(for version: APIVersion) -> String?
+}
+
+extension TokenProvider {
+    func authorizationHeader(for version: APIVersion) -> String? {
+        guard let token = token(for: version) else { return nil }
+
+        switch version {
+        case .GraphQL.v1, .REST.v2:
+            return "Bearer \(token)"
+        default:
+            return nil
+        }
+    }
+}
+
+extension String: TokenProvider {
+    public func token(for version: APIVersion) -> String? {
+        self
+    }
+}

--- a/Sources/Buildkite/Networking/TokenProvider.swift
+++ b/Sources/Buildkite/Networking/TokenProvider.swift
@@ -12,7 +12,9 @@ import Foundation
 import FoundationNetworking
 #endif
 
+///
 public protocol TokenProvider {
+    /// Returns a token string for the given ``APIVersion``. This will usually be a fixed constant such as ``APIVersion/REST/v2`` or ``APIVersion/GraphQL/v1``, so you can switch on the values of one of these.
     func token(for version: APIVersion) -> String?
 }
 
@@ -29,8 +31,11 @@ extension TokenProvider {
     }
 }
 
-extension String: TokenProvider {
-    public func token(for version: APIVersion) -> String? {
-        self
+/// Wrapper for a raw representable token provider
+struct RawTokenProvider: RawRepresentable, TokenProvider {
+    let rawValue: String
+
+    func token(for version: APIVersion) -> String? {
+        rawValue
     }
 }

--- a/Sources/Buildkite/Resources/Followable.swift
+++ b/Sources/Buildkite/Resources/Followable.swift
@@ -14,6 +14,15 @@ import FoundationNetworking
 
 /// Followable is a container resource that allows URLs returned by Buildkite's API to be easily consumed
 /// by the client.
+///
+/// Here's an example of using a ``Followable`` resource:
+///
+/// ```swift
+/// let client = BuildkiteClient(token: "...")
+/// let organizationResponse = await client.send(.organization("buildkite")
+/// let agentsResponse = await client.send(organizationResponse.content.agentsUrl)
+/// print(agentsResponse.content) // Array<Agent>(...)
+/// ```
 public struct Followable<R: Resource>: Codable, Equatable, Resource {
     public typealias Content = R.Content
 

--- a/Tests/BuildkiteTests/BuildkiteClientTests.swift
+++ b/Tests/BuildkiteTests/BuildkiteClientTests.swift
@@ -73,12 +73,13 @@ class BuildkiteClientTests: XCTestCase {
                 responses = []
             }
 
+            let token = "a valid token, i guess"
             client = BuildkiteClient(
                 configuration: configuration,
-                transport: MockTransport(responses: responses)
+                transport: MockTransport(responses: responses),
+                tokens: token
             )
-            client.token = "a valid token, i guess"
-            XCTAssertEqual(client.token, client.configuration.token)
+            XCTAssertEqual(token, token.token(for: .REST.v2))
         }
     }
 

--- a/Tests/BuildkiteTests/BuildkiteClientTests.swift
+++ b/Tests/BuildkiteTests/BuildkiteClientTests.swift
@@ -77,9 +77,9 @@ class BuildkiteClientTests: XCTestCase {
             client = BuildkiteClient(
                 configuration: configuration,
                 transport: MockTransport(responses: responses),
-                tokens: token
+                token: token
             )
-            XCTAssertEqual(token, token.token(for: .REST.v2))
+            XCTAssertEqual(token, RawTokenProvider(rawValue: token).token(for: .REST.v2))
         }
     }
 


### PR DESCRIPTION
This new design will make it so a single client can be used with all sorts of API, even though the authorization requirements for different API versions require different tokens.

For example, you may have an application that requires access to the Buildkite REST API, GraphQL API, Agents API, and Test Analytics API, and each API requires a separately scoped token. This will enable users to continue to access these resources from a single client instance, as well as enable integration with more complex secret management techniques. 