### PR TITLE
Support Agent and Test Analytics APIs

### DIFF
--- a/Sources/Buildkite/Models/AgentMetric.swift
+++ b/Sources/Buildkite/Models/AgentMetric.swift
@@ -1,0 +1,38 @@
+//
+//  AgentMetrics.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/5/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct AgentMetrics: Codable, Equatable {
+    public var agents: AgentTotals
+    public var jobs: JobTotals
+    public var organization: Organization
+
+    public struct AgentTotals: Codable, Equatable {
+        public var idle: Int
+        public var busy: Int
+        public var total: Int
+        public var queues: [String: Int]
+    }
+
+    public struct JobTotals: Codable, Equatable {
+        public var scheduled: Int
+        public var running: Int
+        public var waiting: Int
+        public var total: Int
+        public var queues: [String: Int]
+    }
+
+    public struct Organization: Codable, Equatable {
+        public var slug: String
+    }
+}

--- a/Sources/Buildkite/Models/Trace.swift
+++ b/Sources/Buildkite/Models/Trace.swift
@@ -1,0 +1,69 @@
+//
+//  Trace.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/5/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct Trace: Codable, Equatable, Identifiable {
+    /// a unique identifier for this test result
+    public var id: UUID
+    /// a group or topic for the test
+    ///
+    /// - `Student.isEnrolled()`
+    public var scope: String?
+    /// a name or description for the test
+    ///
+    /// - `Manager.isEnrolled()`
+    /// - `returns_boolean`
+    public var name: String?
+    /// a unique identifier for the test. If your test runner supports it, use the identifier needed to rerun this test
+    ///
+    /// - `Manager.isEnrolled#returns_boolean`
+    public var identifier: String?
+    /// the file and line number where the test originates, separated by a colon (:)
+    ///
+    /// - `./tests/Manager/isEnrolled.js:32`
+    public var location: String?
+    /// the file where the test originates
+    ///
+    /// - `./tests/Manager/isEnrolled.js`
+    public var fileName: String?
+    /// the outcome of the test, e.g. `"passed"`, `"failed"`, `"skipped"`, or `"unknown"``
+    public var result: String?
+    /// if applicable, a short summary of why the test failed
+    ///
+    /// - `Expected Boolean, got Object`
+    public var failureReason: String?
+    /// History object
+    public var history: History
+
+    public struct History: Codable, Equatable {
+        /// A monotonically increasing number
+        public var startAt: Double?
+        /// A monotonically increasing number
+        public var endAt: Double?
+        /// How long the test took to run
+        public var duration: Double
+        /// array of span objects
+        public var children: [Span]? = []
+
+        public struct Span: Codable, Equatable {
+            /// A section category for this span, e.g. `"http"`, `"sql"`, `"sleep"`, or `"annotation"`
+            public var section: String
+            /// A monotonically increasing number
+            public var startAt: Double?
+            /// A monotonically increasing number
+            public var endAt: Double?
+            /// How long the span took to run
+            public var duration: Double?
+        }
+    }
+}

--- a/Sources/Buildkite/Networking/APIVersion.swift
+++ b/Sources/Buildkite/Networking/APIVersion.swift
@@ -23,6 +23,16 @@ public struct APIVersion: Equatable {
         public static let v1 = APIVersion(baseURL: baseURL, version: "v1")
     }
 
+    public enum Agent {
+        private static let baseURL = URL(string: "https://agent.buildkite.com")!
+        public static let v3 = APIVersion(baseURL: baseURL, version: "v3")
+    }
+
+    public enum TestAnalytics {
+        private static let baseURL = URL(string: "https://analytics-api.buildkite.com")!
+        public static let v1 = APIVersion(baseURL: baseURL, version: "v1")
+    }
+
     public let baseURL: URL
     public let version: String
 

--- a/Sources/Buildkite/Networking/Configuration.swift
+++ b/Sources/Buildkite/Networking/Configuration.swift
@@ -16,20 +16,28 @@ public struct Configuration {
     public let userAgent = "buildkite-swift"
     public var version: APIVersion
     public var graphQLVersion: APIVersion
+    public var agentVersion: APIVersion
+    public var testAnalyticsVersion: APIVersion
 
     public static var `default`: Configuration {
         .init(
             version: APIVersion.REST.v2,
-            graphQLVersion: APIVersion.GraphQL.v1
+            graphQLVersion: APIVersion.GraphQL.v1,
+            agentVersion: APIVersion.Agent.v3,
+            testAnalyticsVersion: APIVersion.TestAnalytics.v1
         )
     }
 
     public init(
         version: APIVersion = APIVersion.REST.v2,
-        graphQLVersion: APIVersion = APIVersion.GraphQL.v1
+        graphQLVersion: APIVersion = APIVersion.GraphQL.v1,
+        agentVersion: APIVersion = APIVersion.Agent.v3,
+        testAnalyticsVersion: APIVersion = APIVersion.TestAnalytics.v1
     ) {
         self.version = version
         self.graphQLVersion = graphQLVersion
+        self.agentVersion = agentVersion
+        self.testAnalyticsVersion = testAnalyticsVersion
     }
 
     func transformRequest(

--- a/Sources/Buildkite/Networking/Resource.swift
+++ b/Sources/Buildkite/Networking/Resource.swift
@@ -52,6 +52,8 @@ extension URLRequest {
         guard
             version == configuration.version
                 || version == configuration.graphQLVersion
+                || version == configuration.agentVersion
+                || version == configuration.testAnalyticsVersion
         else {
             throw ResourceError.incompatibleVersion(version)
         }

--- a/Sources/Buildkite/Networking/TokenProvider.swift
+++ b/Sources/Buildkite/Networking/TokenProvider.swift
@@ -25,6 +25,10 @@ extension TokenProvider {
         switch version {
         case .GraphQL.v1, .REST.v2:
             return "Bearer \(token)"
+        case .Agent.v3:
+            return "Token \(token)"
+        case .TestAnalytics.v1:
+            return "Token token=\(token)"
         default:
             return nil
         }

--- a/Sources/Buildkite/Resources/Agent/AgentMetrics.swift
+++ b/Sources/Buildkite/Resources/Agent/AgentMetrics.swift
@@ -1,0 +1,42 @@
+//
+//  AgentMetrics.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/5/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AgentMetrics {
+    /// Resources for requesting information about your organization's Buildkite agents.
+    public enum Resources {}
+}
+
+extension AgentMetrics.Resources {
+    /// Get metrics about agents active with the current organization.
+    public struct Get: Resource {
+        public typealias Content = AgentMetrics
+
+        public var version: APIVersion {
+            APIVersion.Agent.v3
+        }
+
+        public let path = "metrics"
+
+        public init() {}
+    }
+}
+
+extension Resource where Self == AgentMetrics.Resources.Get {
+    /// Get an object with properties describing Buildkite
+    ///
+    /// Returns meta information about Buildkite.
+    public static var agentMetrics: Self {
+        Self()
+    }
+}

--- a/Sources/Buildkite/Resources/TestAnalytics/TestAnalyticsUpload.swift
+++ b/Sources/Buildkite/Resources/TestAnalytics/TestAnalyticsUpload.swift
@@ -1,0 +1,70 @@
+//
+//  TestAnalyticsUpload.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/5/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum TestAnalytics {
+    /// Resources for requesting information about your organization's Buildkite agents.
+    public enum Resources {}
+}
+
+extension TestAnalytics.Resources {
+    /// Get metrics about agents active with the current organization.
+    public struct Upload: Resource {
+        public typealias Content = String
+
+        public struct Body: Encodable {
+            public var format: String
+            public var environment: Environment
+            public var data: [Trace]
+
+            public struct Environment: Encodable {
+                public var ci: String
+                public var key: String
+                public var number: String?
+                public var jobId: String?
+                public var branch: String?
+                public var commitSha: String?
+                public var message: String?
+                public var url: String?
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case format
+                case environment = "runEnv"
+                case data
+            }
+        }
+
+        public var version: APIVersion {
+            APIVersion.TestAnalytics.v1
+        }
+
+        public let path = "upload"
+
+        /// body of the request
+        public var body: Body
+
+        public init(body: Body) {
+            self.body = body
+        }
+    }
+}
+
+extension Resource where Self == TestAnalytics.Resources.Upload {
+    /// Get an object with properties describing Buildkite
+    ///
+    /// Returns meta information about Buildkite.
+    public static func uploadTestAnalytics(_ data: [Trace], environment: Self.Body.Environment) -> Self {
+        Self(body: .init(format: "json", environment: environment, data: data))
+    }
+}

--- a/Tests/BuildkiteTests/Resources/Agent/AgentMetricsTests.swift
+++ b/Tests/BuildkiteTests/Resources/Agent/AgentMetricsTests.swift
@@ -1,0 +1,50 @@
+//
+//  AgentMetricsTests.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/5/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import Buildkite
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AgentMetrics {
+    init() {
+        self.init(
+            agents: .init(
+                idle: 0,
+                busy: 0,
+                total: 0,
+                queues: [:]
+            ),
+            jobs: .init(
+                scheduled: 0,
+                running: 0,
+                waiting: 0,
+                total: 0,
+                queues: [:]
+            ),
+            organization: .init(
+                slug: "buildkite"
+            )
+        )
+    }
+}
+
+class AgentMetricsTests: XCTestCase {
+    func testAgentMetricsGet() async throws {
+        let expected = AgentMetrics()
+        let context = try MockContext(content: expected)
+
+        let response = try await context.client.send(.agentMetrics)
+
+        XCTAssertEqual(expected, response.content)
+    }
+}

--- a/Tests/BuildkiteTests/Resources/TestAnalytics/TestAnalyticsUploadTests.swift
+++ b/Tests/BuildkiteTests/Resources/TestAnalytics/TestAnalyticsUploadTests.swift
@@ -1,0 +1,33 @@
+//
+//  TestAnalyticsUploadTests.swift
+//  Buildkite
+//
+//  Created by Aaron Sky on 6/6/22.
+//  Copyright © 2022 Aaron Sky. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import Buildkite
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+class TestAnalyticsUpload: XCTestCase {
+    func testTestAnalyticsUpload() async throws {
+        let traces: [Trace] = [
+            .init(id: .init(), history: .init(duration: 0)),
+            .init(id: .init(), history: .init(duration: 0)),
+            .init(id: .init(), history: .init(duration: 0))
+        ]
+        let environment: TestAnalytics.Resources.Upload.Body.Environment = .init(ci: "buildkite", key: "test")
+        let expected = "dogs"
+        let context = try MockContext(content: expected)
+
+        let response = try await context.client.send(.uploadTestAnalytics(traces, environment: environment))
+
+        XCTAssertEqual(expected, response.content)
+    }
+}


### PR DESCRIPTION
There are some structural changes required to support the Agent and Test Analytics APIs, but going forward it should be even easier to support these "other APIs".
